### PR TITLE
Add PySide6 based gerber viewer

### DIFF
--- a/pcb_viewer/__init__.py
+++ b/pcb_viewer/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Gerber viewer utilities."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/pcb_viewer/__main__.py
+++ b/pcb_viewer/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/pcb_viewer/gerber_utils.py
+++ b/pcb_viewer/gerber_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Iterable
+
+from pygerber.gerber.api import GerberFile, FileTypeEnum
+import gerber.excellon as excellon
+
+
+@dataclass
+class GerberLayer:
+    file_path: Path
+    gerber: GerberFile
+    file_type: FileTypeEnum
+
+
+def load_gerber_directory(path: Path) -> List[GerberLayer]:
+    """Load all Gerber files from directory."""
+    layers: List[GerberLayer] = []
+    for p in sorted(path.iterdir()):
+        if not p.is_file():
+            continue
+        if p.suffix.lower() in {".gbr", ".grb", ".gtl", ".gbl", ".gts", ".gbs", ".gto", ".gbo", ".gtp", ".gbp", ".drl", ".txt"}:
+            # Drill files are also collected but not parsed as Gerber
+            if p.suffix.lower() in {".drl", ".txt"}:
+                # store as None for gerber
+                gf = None
+                file_type = FileTypeEnum.OTHER
+            else:
+                gf = GerberFile.from_file(p, file_type=FileTypeEnum.INFER)
+                file_type = gf.file_type
+            layers.append(GerberLayer(p, gf, file_type))
+    return layers
+
+
+def parse_drill_file(path: Path):
+    """Parse Excellon drill file and return list of (x, y, diameter) in mm."""
+    ef = excellon.read(str(path))
+    ef.to_metric()
+    drills = []
+    for hit in ef.hits:
+        if isinstance(hit, excellon.DrillHit):
+            drills.append((hit.position[0], hit.position[1], hit.tool.diameter))
+    return drills
+
+
+def export_gcode(drills: Iterable[tuple[float, float, float]], out_path: Path, depth: float = -1.0) -> None:
+    """Export drill hits to a very simple G-code program."""
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write("G90\n")  # absolute
+        f.write("G21\n")  # mm units
+        f.write("G0 Z5\n")
+        f.write("M3\n")
+        for x, y, _diam in drills:
+            f.write(f"G0 X{x:.4f} Y{y:.4f}\n")
+            f.write(f"G1 Z{depth} F200\n")
+            f.write("G0 Z5\n")
+        f.write("M5\nM30\n")

--- a/pcb_viewer/main.py
+++ b/pcb_viewer/main.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QListWidget,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QMessageBox,
+)
+
+from .gerber_utils import load_gerber_directory, parse_drill_file, export_gcode, GerberLayer
+
+
+class MainWindow(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Gerber Viewer")
+        self.open_button = QPushButton("Open Gerber Folder")
+        self.export_svg_button = QPushButton("Export SVGs")
+        self.export_gcode_button = QPushButton("Export Drill G-code")
+        self.layer_list = QListWidget()
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.open_button)
+        layout.addWidget(self.layer_list)
+        layout.addWidget(self.export_svg_button)
+        layout.addWidget(self.export_gcode_button)
+        self.setLayout(layout)
+
+        self.open_button.clicked.connect(self.open_folder)
+        self.export_svg_button.clicked.connect(self.export_svgs)
+        self.export_gcode_button.clicked.connect(self.export_drills)
+
+        self.layers: List[GerberLayer] = []
+
+    def open_folder(self) -> None:
+        folder = QFileDialog.getExistingDirectory(self, "Select Gerber Folder")
+        if not folder:
+            return
+        self.layers = load_gerber_directory(Path(folder))
+        self.layer_list.clear()
+        for layer in self.layers:
+            self.layer_list.addItem(f"{layer.file_path.name} [{layer.file_type.name}]")
+        QMessageBox.information(self, "Layers Loaded", f"Detected {len(self.layers)} files")
+
+    def export_svgs(self) -> None:
+        if not self.layers:
+            return
+        out_dir = QFileDialog.getExistingDirectory(self, "Select Output Directory")
+        if not out_dir:
+            return
+        for layer in self.layers:
+            if layer.gerber is None:
+                continue
+            svg_path = Path(out_dir) / f"{layer.file_path.stem}.svg"
+            layer.gerber.render_with_shapely().save_svg(svg_path)
+        QMessageBox.information(self, "Done", "SVG export finished")
+
+    def export_drills(self) -> None:
+        drill_files = [l.file_path for l in self.layers if l.file_path.suffix.lower() in {".drl", ".txt"}]
+        if not drill_files:
+            QMessageBox.warning(self, "No Drill Files", "No drill files found")
+            return
+        drills = []
+        for df in drill_files:
+            drills.extend(parse_drill_file(df))
+        path, _ = QFileDialog.getSaveFileName(self, "Save G-code", "drill.gcode", "GCODE Files (*.gcode)")
+        if not path:
+            return
+        export_gcode(drills, Path(path))
+        QMessageBox.information(self, "Done", "G-code exported")
+
+
+def main() -> None:
+    app = QApplication([])
+    win = MainWindow()
+    win.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple gerber loading utilities using PyGerber 3.x
- parse Excellon drill files and export to gcode
- build a PySide6 GUI to load gerber folders and export layers as SVG

## Testing
- `python -m pcb_viewer --help` *(fails: ImportError: libEGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_68649798d7a483328d0b4a5c66740ae0